### PR TITLE
Localize datetime objects when time zone support is active

### DIFF
--- a/django_factory_boy/auth.py
+++ b/django_factory_boy/auth.py
@@ -5,8 +5,10 @@
 
 import datetime
 
+from django.conf import settings
 from django.contrib.auth import models
 from django.contrib.contenttypes import models as contenttypes_models
+from django.utils import timezone
 
 import factory
 import factory.django
@@ -17,6 +19,8 @@ __all__ = (
     'PermissionFactory',
     'GroupFactory'
 )
+
+tzinfo = timezone.get_current_timezone() if settings.USE_TZ else None
 
 class PermissionFactory(factory.django.DjangoModelFactory):
     class Meta:
@@ -48,5 +52,5 @@ class UserFactory(factory.django.DjangoModelFactory):
     is_staff = False
     is_superuser = False
 
-    last_login = datetime.datetime(2000, 1, 1)
-    date_joined = datetime.datetime(1999, 1, 1)
+    last_login = datetime.datetime(2000, 1, 1, tzinfo=tzinfo)
+    date_joined = datetime.datetime(1999, 1, 1, tzinfo=tzinfo)


### PR DESCRIPTION
`UserFactory` builds naive datetime objects for `last_login` and `date_joined`.

So, when the time zone support is disabled (`USE_TZ` is set to `False`), everything works fine.

However, when enabled, the factory raises warnings:

```
/Users/xavierdutreilh/.virtualenvs/***/lib/python3.5/site-packages/django/db/models/fields/__init__.py:1453: RuntimeWarning: DateTimeField User.last_login received a naive datetime (2000-01-01 00:00:00) while time zone support is active.
  RuntimeWarning)

/Users/xavierdutreilh/.virtualenvs/***/lib/python3.5/site-packages/django/db/models/fields/__init__.py:1453: RuntimeWarning: DateTimeField User.date_joined received a naive datetime (1999-01-01 00:00:00) while time zone support is active.
  RuntimeWarning)
```
